### PR TITLE
Use region from env for boto3 clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ Lambda函数使用以下环境变量（CDK自动设置）：
 - `TBL`: TimeStream表名称  
 - `BUCKET`: S3存储桶名称
 - `REGION`: AWS区域
+  
+CDK会在部署Lambda时自动设置该变量，确保在创建boto3客户端时使用期望的AWS区域。
 
 ### IoT Topic格式
 

--- a/lambda/processor.py
+++ b/lambda/processor.py
@@ -17,16 +17,16 @@ from botocore.exceptions import ClientError
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-# Initialize AWS clients
-ts_client = boto3.client("timestream-write")
-s3_client = boto3.client("s3")
-
 # Environment variables
 DB = os.environ["TDB"]
 TBL = os.environ["TBL"]
 BUCKET = os.environ["BUCKET"]
 REGION = os.environ["REGION"]
 SQS_QUEUE_URL = os.environ.get("SQS_QUEUE_URL", "")
+
+# Initialize AWS clients with explicit region
+ts_client = boto3.client("timestream-write", region_name=REGION)
+s3_client = boto3.client("s3", region_name=REGION)
 
 
 def extract_device_id(payload: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- scope boto3 clients to the lambda's AWS region
- document that CDK sets the REGION env var for the Lambda

## Testing
- `TDB=test TBL=test BUCKET=test REGION=us-west-2 SQS_QUEUE_URL=test python lambda/processor.py`

------
https://chatgpt.com/codex/tasks/task_e_68469e7c090083258e3151bbbd4883ce