### PR TITLE
Fix OTA job ARN generation

### DIFF
--- a/lambda/ota_manager.py
+++ b/lambda/ota_manager.py
@@ -184,9 +184,15 @@ def create_ota_job(device_targets: List[str], firmware_version: str, device_type
         }
         
         # Create IoT job
+        # Resolve AWS account ID using STS to avoid parsing credentials
+        account_id = boto3.client("sts").get_caller_identity()["Account"]
+
         iot_response = iot_client.create_job(
             jobId=job_id,
-            targets=[f"arn:aws:iot:{REGION}:{boto3.Session().get_credentials().access_key.split(':')[4]}:thing/{device_id}" for device_id in device_targets],
+            targets=[
+                f"arn:aws:iot:{REGION}:{account_id}:thing/{device_id}"
+                for device_id in device_targets
+            ],
             document=json.dumps(job_document),
             description=f"Firmware update to version {firmware_version}",
             targetSelection="SNAPSHOT",


### PR DESCRIPTION
## Summary
- fetch AWS account ID with STS
- build OTA job target ARNs using the account ID

## Testing
- `pytest -q` *(fails: ImportError - cannot import name 'mock_dynamodb' from 'moto')*

------
https://chatgpt.com/codex/tasks/task_e_684a2710bd388325b84faeb19df836bc