### PR TITLE
Fix removal policy setting

### DIFF
--- a/iot_poc/auth_stack.py
+++ b/iot_poc/auth_stack.py
@@ -4,7 +4,7 @@ Implements user authentication, authorization, and management for IoT platform
 """
 
 from aws_cdk import (
-    Stack, Duration, CfnOutput,
+    Stack, Duration, CfnOutput, RemovalPolicy,
     aws_cognito as cognito,
     aws_lambda as _lambda,
     aws_iam as iam,
@@ -46,7 +46,7 @@ class AuthStack(Stack):
                 otp=True
             ),
             account_recovery=cognito.AccountRecovery.EMAIL_ONLY,
-            removal_policy=Stack.of(self).removal_policy
+            removal_policy=RemovalPolicy.DESTROY
         )
 
         # User Pool Client for web/mobile apps
@@ -89,7 +89,7 @@ class AuthStack(Stack):
             ),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
             point_in_time_recovery=True,
-            removal_policy=Stack.of(self).removal_policy
+            removal_policy=RemovalPolicy.DESTROY
         )
 
         # Add GSI for role-based queries
@@ -118,7 +118,7 @@ class AuthStack(Stack):
                 type=dynamodb.AttributeType.STRING
             ),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
-            removal_policy=Stack.of(self).removal_policy
+            removal_policy=RemovalPolicy.DESTROY
         )
 
         # 5️⃣ Lambda authorizer function

--- a/iot_poc/device_shadow_stack.py
+++ b/iot_poc/device_shadow_stack.py
@@ -4,7 +4,7 @@ Implements AWS IoT Device Shadow service for device state management
 """
 
 from aws_cdk import (
-    Stack, Duration, CfnOutput,
+    Stack, Duration, CfnOutput, RemovalPolicy,
     aws_iot as iot,
     aws_lambda as _lambda,
     aws_iam as iam,
@@ -39,7 +39,7 @@ class DeviceShadowStack(Stack):
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
             time_to_live_attribute="ttl",
             point_in_time_recovery=True,
-            removal_policy=Stack.of(self).removal_policy
+            removal_policy=RemovalPolicy.DESTROY
         )
 
         # Add GSI for querying by status

--- a/iot_poc/ota_stack.py
+++ b/iot_poc/ota_stack.py
@@ -4,7 +4,7 @@ Implements device firmware update functionality using AWS IoT Device Management
 """
 
 from aws_cdk import (
-    Stack, Duration, CfnOutput,
+    Stack, Duration, CfnOutput, RemovalPolicy,
     aws_iot as iot,
     aws_s3 as s3,
     aws_lambda as _lambda,
@@ -56,7 +56,7 @@ class OtaStack(Stack):
             ),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
             point_in_time_recovery=True,
-            removal_policy=Stack.of(self).removal_policy
+            removal_policy=RemovalPolicy.DESTROY
         )
 
         # Add GSI for device-based queries
@@ -85,7 +85,7 @@ class OtaStack(Stack):
                 type=dynamodb.AttributeType.STRING
             ),
             billing_mode=dynamodb.BillingMode.PAY_PER_REQUEST,
-            removal_policy=Stack.of(self).removal_policy
+            removal_policy=RemovalPolicy.DESTROY
         )
 
         # 4️⃣ Lambda function for OTA management


### PR DESCRIPTION
## Summary
- import `RemovalPolicy` in stacks
- set removal policy to `RemovalPolicy.DESTROY`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'boto3')*

------
https://chatgpt.com/codex/tasks/task_e_684a2747f1248325b2173b7db612b372