### PR TITLE
Refactor auth handler path checks

### DIFF
--- a/lambda/auth_manager.py
+++ b/lambda/auth_manager.py
@@ -404,44 +404,57 @@ def handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     
     try:
         # Routes handling
-        if "/users" in path and method == "GET":
+        segments = path.strip("/").split("/")
+
+        if path == "/users" and method == "GET":
             # Get all users (admin only)
             if current_user_role != "admin":
                 return {
                     "statusCode": 403,
                     "body": {"error": "Insufficient permissions"}
                 }
-            
+
             role_filter = query_parameters.get("role")
             return get_all_users(role_filter)
-            
-        elif "/users/{user_id}" in path and method == "GET":
+
+        elif len(segments) == 2 and segments[0] == "users" and method == "GET":
             # Get specific user profile
             target_user_id = path_parameters.get("user_id")
-            
+
             # Users can only access their own profile unless they're admin
             if current_user_role != "admin" and current_user_id != target_user_id:
                 return {
                     "statusCode": 403,
                     "body": {"error": "Insufficient permissions"}
                 }
-            
+
             return get_user_profile(target_user_id)
-            
-        elif "/users/{user_id}/permissions" in path and method == "GET":
+
+        elif (
+            len(segments) == 3
+            and segments[0] == "users"
+            and segments[2] == "permissions"
+            and method == "GET"
+        ):
             # Get user's device permissions
             target_user_id = path_parameters.get("user_id")
-            
+
             # Users can only access their own permissions unless they're admin
             if current_user_role != "admin" and current_user_id != target_user_id:
                 return {
                     "statusCode": 403,
                     "body": {"error": "Insufficient permissions"}
                 }
-            
+
             return get_user_device_permissions(target_user_id)
-            
-        elif "/users/{user_id}/permissions/devices" in path and method == "POST":
+
+        elif (
+            len(segments) == 4
+            and segments[0] == "users"
+            and segments[2] == "permissions"
+            and segments[3] == "devices"
+            and method == "POST"
+        ):
             # Grant device permissions (admin only)
             if current_user_role != "admin":
                 return {

--- a/tests/test_auth_manager_routes.py
+++ b/tests/test_auth_manager_routes.py
@@ -1,0 +1,61 @@
+import os
+import importlib.util
+from unittest.mock import patch, MagicMock
+
+import boto3
+
+
+def load_auth_manager(monkeypatch):
+    monkeypatch.setenv("USER_PROFILE_TABLE", "test_user_table")
+    monkeypatch.setenv("DEVICE_PERMISSIONS_TABLE", "test_perm_table")
+    monkeypatch.setenv("USER_POOL_ID", "pool")
+    monkeypatch.setenv("REGION", "us-east-1")
+
+    monkeypatch.setattr(boto3, "client", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(boto3, "resource", lambda *a, **k: MagicMock())
+
+    spec = importlib.util.spec_from_file_location(
+        "auth_manager", os.path.join(os.path.dirname(__file__), "..", "lambda", "auth_manager.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_user_profile_route(monkeypatch):
+    auth_manager = load_auth_manager(monkeypatch)
+    with patch.object(auth_manager, "extract_user_info_from_jwt", return_value={"user_id": "123", "role": "admin"}):
+        with patch.object(auth_manager, "get_user_profile", return_value={"statusCode": 200}) as get_profile:
+            event = {"httpMethod": "GET", "path": "/users/123", "pathParameters": {"user_id": "123"}}
+            resp = auth_manager.handler(event, None)
+            assert resp["statusCode"] == 200
+            get_profile.assert_called_once_with("123")
+
+
+def test_get_user_permissions_route(monkeypatch):
+    auth_manager = load_auth_manager(monkeypatch)
+    with patch.object(auth_manager, "extract_user_info_from_jwt", return_value={"user_id": "123", "role": "admin"}):
+        with patch.object(auth_manager, "get_user_device_permissions", return_value={"statusCode": 200}) as get_perms:
+            event = {
+                "httpMethod": "GET",
+                "path": "/users/123/permissions",
+                "pathParameters": {"user_id": "123"},
+            }
+            resp = auth_manager.handler(event, None)
+            assert resp["statusCode"] == 200
+            get_perms.assert_called_once_with("123")
+
+
+def test_grant_device_permission_route(monkeypatch):
+    auth_manager = load_auth_manager(monkeypatch)
+    with patch.object(auth_manager, "extract_user_info_from_jwt", return_value={"user_id": "admin", "role": "admin"}):
+        with patch.object(auth_manager, "grant_device_permission", return_value={"statusCode": 200}) as grant_perm:
+            event = {
+                "httpMethod": "POST",
+                "path": "/users/123/permissions/devices",
+                "pathParameters": {"user_id": "123"},
+                "body": "{}",
+            }
+            resp = auth_manager.handler(event, None)
+            assert resp["statusCode"] == 200
+            grant_perm.assert_called_once_with("123", None, [])


### PR DESCRIPTION
## Summary
- remove stray shell output from `auth_manager`
- use path-based routing in the auth lambda handler
- add unit tests for new routing logic

## Testing
- `pytest tests/test_auth_manager_routes.py -q` *(fails: ModuleNotFoundError: No module named 'moto')*

------
https://chatgpt.com/codex/tasks/task_e_684a271b2a248325b0d11fc7a973e6fe