### PR TITLE
Fix route53 targets import for ECS stack

### DIFF
--- a/iot_poc/ecs_api_stack.py
+++ b/iot_poc/ecs_api_stack.py
@@ -11,6 +11,7 @@ from aws_cdk import (
     aws_logs as logs,
     aws_iam as iam,
     aws_route53 as route53,
+    aws_route53_targets as route53_targets,
     aws_certificatemanager as acm,
     aws_servicediscovery as servicediscovery,
     aws_apigateway as apigateway,


### PR DESCRIPTION
## Summary
- add missing aws_route53_targets import for `EcsApiStack`

## Testing
- `python - <<'PY'
import aws_cdk as cdk
from iot_poc.ecs_api_stack import EcsApiStack
app = cdk.App()
stack = EcsApiStack(app, "TestStack")
app.synth()
print('synth succeed')
PY`
- `pytest -q` *(fails: errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684a271740e083259e88d797bcd0032d